### PR TITLE
Add AIS-catcher Home Assistant app

### DIFF
--- a/.github/workflows/ais-catcher-checks.yml
+++ b/.github/workflows/ais-catcher-checks.yml
@@ -1,0 +1,52 @@
+name: AIS-catcher checks
+
+on:
+  push:
+    paths:
+      - ais-catcher/**
+      - .github/workflows/ais-catcher-checks.yml
+  pull_request:
+    paths:
+      - ais-catcher/**
+      - .github/workflows/ais-catcher-checks.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  configuration:
+    name: Configuration and shell checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install YAML validator
+        run: sudo apt-get update && sudo apt-get install --yes yq
+      - name: Run checks
+        run: |
+          ./ais-catcher/tests/check.sh
+          shellcheck ais-catcher/run.sh ais-catcher/tests/check.sh
+
+  image:
+    name: Build image without hardware
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build amd64 image
+        run: docker build --build-arg BUILD_ARCH=amd64 --tag local/ais-catcher:test ais-catcher
+      - name: Start no-hardware mode
+        run: |
+          docker run --detach --name ais-catcher-test \
+            --publish 8100:8100 \
+            --volume "$PWD/ais-catcher/tests/options/no-hardware.json:/data/options.json:ro" \
+            local/ais-catcher:test
+          trap 'docker logs ais-catcher-test; docker rm --force ais-catcher-test' EXIT
+          for attempt in {1..30}
+          do
+            if curl --fail --silent http://127.0.0.1:8100/ >/dev/null
+            then
+              exit 0
+            fi
+            sleep 1
+          done
+          exit 1

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -26,7 +26,13 @@ jobs:
       - name: Read version
         id: version
         run: |
-          echo "version=$(jq -r .version '${{ inputs.app }}/config.json')" >> "$GITHUB_OUTPUT"
+          if [[ -f '${{ inputs.app }}/config.json' ]]
+          then
+            version=$(jq -r .version '${{ inputs.app }}/config.json')
+          else
+            version=$(ruby -e 'require "yaml"; puts YAML.load_file(ARGV[0])["version"]' '${{ inputs.app }}/config.yaml')
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Read extra build args from build.json
         id: build_args

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -30,7 +30,7 @@ jobs:
           then
             version=$(jq -r .version '${{ inputs.app }}/config.json')
           else
-            version=$(ruby -e 'require "yaml"; puts YAML.load_file(ARGV[0])["version"]' '${{ inputs.app }}/config.yaml')
+            version=$(ruby -e 'require "yaml"; puts YAML.safe_load(File.read(ARGV[0]), aliases: false).fetch("version")' '${{ inputs.app }}/config.yaml')
           fi
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,8 @@ jobs:
             architectures: '["aarch64", "amd64"]'
           - app: zabbix-agent2
             architectures: '["aarch64", "amd64"]'
+          - app: ais-catcher
+            architectures: '["aarch64", "amd64"]'
     uses: ./.github/workflows/build-app.yml
     with:
       app: ${{ matrix.app }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,7 @@ jobs:
           - app: tailscale
           - app: zabbix-agent
           - app: zabbix-agent2
+          - app: ais-catcher
     steps:
       - uses: actions/checkout@v7
       - name: Install hadolint

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 Home Assistant apps by Philipp Schmitt
 
+## AIS-catcher
+
+The [`ais-catcher/`](ais-catcher/) app receives AIS traffic with an RTL-SDR
+and the upstream AIS-catcher decoder. It supports Home Assistant ingress,
+native NMEA outputs, AISHub, and optional AIS-catcher community sharing. An
+explicit no-hardware development mode is available for validation before an
+SDR is installed.
+
 Add to Home Assistant using the repository url:
 https://github.com/pschmitt/home-assistant-apps
 

--- a/ais-catcher/CHANGELOG.md
+++ b/ais-catcher/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0
+
+- Initial experimental Home Assistant OS app.
+- Build AIS-catcher v0.70 from a pinned upstream source commit.
+- Add native RTL-SDR input, web ingress, UDP/TCP NMEA output, AISHub output,
+  and optional aiscatcher.org community sharing.
+- Add an explicit no-hardware development mode that does not simulate radio
+  reception.

--- a/ais-catcher/DOCS.md
+++ b/ais-catcher/DOCS.md
@@ -1,0 +1,278 @@
+# AIS-catcher Home Assistant app
+
+## Installation
+
+In Home Assistant, open **Settings → Add-ons → Add-on Store**, select the
+three-dot menu, choose **Repositories**, and add:
+
+```text
+https://github.com/pschmitt/home-assistant-apps
+```
+
+Install **AIS-catcher**. The app is built for `amd64` and `aarch64`, which
+includes generic x86-64 systems and 64-bit Raspberry Pi Home Assistant OS
+installations. The add-on has no public port mapping; its web viewer is
+available through Home Assistant ingress.
+
+## Basic configuration
+
+The default options are suitable as a starting point:
+
+```yaml
+hardware_required: true
+receiver:
+  device: auto
+  gain: auto
+  ppm: 0
+  rtlagc: false
+  sample_rate: 1536000
+  bandwidth: 192000
+  channel: AB
+web:
+  enabled: true
+udp_outputs: []
+tcp_outputs: []
+aishub:
+  enabled: false
+  host: ""
+  port: 0
+aiscatcher_share:
+  enabled: false
+  key: ""
+log_level: info
+```
+
+`receiver.device` is `auto` by default. For multiple RTL-SDR devices, set it
+to the serial number printed by the startup enumeration. `gain` is either
+`auto` or a tuner gain in dB from 0 to 50. Start with `auto` and adjust only
+after looking at the signal-level and message statistics in the web viewer.
+`ppm` accepts -150 through 150. `channel: AB` covers AIS1 and AIS2 with one
+RTL-SDR; `CD` is available for the alternate channel pair supported by
+AIS-catcher.
+
+`udp_outputs` and `tcp_outputs` are lists of NMEA destinations, for example:
+
+```yaml
+udp_outputs:
+  - host: 192.0.2.10
+    port: 10110
+tcp_outputs:
+  - host: ais-consumer.example
+    port: 4001
+```
+
+These are AIS-catcher TCP clients, not TCP listeners. AISHub is also a native
+AIS-catcher UDP NMEA output. Enter the host and port supplied by AISHub; the
+app never fetches AISstream or any other public AIS API.
+
+The `aiscatcher_share` option enables the upstream `sharing` / `sharing_key`
+configuration. Register the station at [aiscatcher.org](https://www.aiscatcher.org/)
+to obtain a sharing key. Sharing is disabled by default.
+
+The key field uses Home Assistant's `password` schema type and is not printed
+by the startup script. It is still present in Supervisor's `/data/options.json`
+and in the generated `/data/aiscatcher.json` (mode `0600`), so this is not a
+replacement for a separate secrets vault. Do not paste it into bug reports or
+share generated configuration files.
+
+## Upstream and Home Assistant compatibility
+
+This app currently builds AIS-catcher [v0.70](https://github.com/jvde-github/AIS-catcher/releases/tag/v0.70)
+from a pinned commit and source archive checksum. The generator uses the
+upstream version-1 JSON configuration format: `receiver` selects `rtlsdr`,
+`udp` and `tcp` carry NMEA outputs, `server` enables the viewer, and `sharing`
+with `sharing_key` enables the upstream community feed. The image compiles
+only the RTL-SDR, web viewer, OpenSSL, and zlib integrations to keep the image
+focused. It also applies one small security patch to the upstream network
+startup messages so a configured community UUID is logged as `[redacted]`.
+The sharing protocol and wire format remain upstream AIS-catcher behavior.
+
+The add-on metadata is in the current `config.yaml` format. `build.yaml` is
+retained as an empty compatibility file for this repository; the pinned base
+images and build settings are intentionally declared in the Dockerfile.
+
+## Connecting and checking the NESDR Smart v5
+
+Connect the NESDR directly to the Home Assistant OS host, or use a powered USB
+hub if the host cannot provide stable power. The app sets `usb: true`, which
+maps Home Assistant OS's raw `/dev/bus/usb` tree into the container and allows
+plug-and-play enumeration. No vendor/product ID is hardcoded; AIS-catcher
+selects the first compatible RTL-SDR or the configured serial number.
+
+After connecting the receiver:
+
+1. Check host hardware from the Home Assistant CLI or Terminal/SSH app with
+   `ha hardware info` where supported. For a diagnostic host shell, `lsusb`
+   and `dmesg`/`journalctl -k` can confirm USB enumeration.
+2. Restart the app and inspect its log. Hardware mode runs
+   `AIS-catcher -l JSON on` first, then prints AIS-catcher's device initialization
+   messages.
+3. A successful startup identifies an RTL-SDR and continues into the receiver
+   loop. `cannot find device`, `no devices available`, `cannot open device`,
+   or `access denied` indicate a host/USB/driver problem, not a reception
+   result.
+4. Open the app from the Home Assistant sidebar and check the receiver,
+   signal, and message statistics. A map with no vessels is not by itself
+   proof that the radio is broken; continue with the antenna and frequency
+   checks below.
+
+App logs can be viewed in the UI or with the Home Assistant CLI:
+
+```sh
+ha addons logs ais-catcher
+ha addons info ais-catcher
+```
+
+For a repository-installed copy whose Supervisor slug is prefixed with
+`local_`, use `ha addons logs local_ais-catcher` instead. The exact slug is
+shown by `ha addons list` or in the add-on information page.
+
+## Antenna and reception
+
+AIS is received in the maritime VHF band. Use a vertically polarized antenna
+designed for approximately 162 MHz, installed as high and unobstructed as is
+practical, with a short, good-quality 50-ohm coax run. A marine VHF antenna
+with an appropriate splitter can work, but the splitter must protect the
+receiver from transmitter power. Do not connect a transmitting radio directly
+to the NESDR.
+
+Once the receiver is initialized, verify both AIS channels:
+
+* AIS1: **161.975 MHz**
+* AIS2: **162.025 MHz**
+
+AIS-catcher's `AB` mode is intended to receive both channels around 162 MHz.
+Use the web viewer's signal/drift information to tune PPM and gain. Excessive
+gain can overload the tuner just as readily as too little gain can hide weak
+signals.
+
+## Web UI and ingress
+
+The built-in AIS-catcher web viewer listens on container port 8100 when
+`web.enabled` is true. Home Assistant ingress proxies that port and handles
+Home Assistant authentication. No host port is published by this app.
+
+Setting `web.enabled` to `false` deliberately disables the viewer; the
+sidebar ingress entry will then be unavailable until it is enabled again.
+
+Ingress has only been validated structurally in this repository. Its behavior
+through a particular Supervisor/Frontend version should be checked on the
+target Home Assistant OS system.
+
+## Development without an SDR
+
+The `hardware_required: false` option is specifically for development and
+configuration checks. In this mode, the generated configuration has an
+AIS-catcher `udpserver` receiver bound to `127.0.0.1:10110`. It waits for
+NMEA input but does not create a radio source and does not invent traffic.
+
+Build and run it on an amd64 development machine:
+
+```sh
+docker build --build-arg BUILD_ARCH=amd64 -t local/ais-catcher:dev ais-catcher
+docker run --rm --name ais-catcher-dev \
+  --publish 8100:8100 \
+  --volume "$PWD/ais-catcher/tests/options/no-hardware.json:/data/options.json:ro" \
+  local/ais-catcher:dev
+```
+
+Open `http://127.0.0.1:8100`. The interface should load and show that no
+receiver messages are arriving. This tests the image, options parsing, config
+generation, and web process without claiming SDR or AIS success.
+
+To inspect a generated configuration without Docker:
+
+```sh
+python3 ais-catcher/generate_config.py \
+  --options ais-catcher/tests/options/full.json \
+  --output /tmp/aiscatcher.json \
+  --print-redacted
+```
+
+The normal production mode remains `hardware_required: true`. Without the
+physical device, AIS-catcher will report that no compatible device is
+available and exit; this is intentional and makes a missing receiver visible
+instead of creating fake reception.
+
+## AISHub and community sharing
+
+For AISHub, obtain the station endpoint from AISHub and set `aishub.enabled`,
+`aishub.host`, and `aishub.port`. AIS-catcher sends the locally decoded raw
+NMEA output directly to that UDP endpoint. With no SDR, no AISHub packets are
+generated by this app.
+
+For the community feed, register at aiscatcher.org, put the supplied key in
+`aiscatcher_share.key`, and set `aiscatcher_share.enabled` to `true`. The
+upstream AIS-catcher community mechanism is used; this app does not implement
+or proxy that protocol.
+
+## Troubleshooting
+
+### No RTL-SDR detected
+
+Check `ha hardware info`, then inspect kernel USB logs. Restart the app after
+plugging in the dongle. In the app log, AIS-catcher's `-l JSON on` output should
+include the RTL-SDR. If several devices
+are present, use the exact serial number in `receiver.device`.
+
+### Permission or access failure
+
+Confirm that the app is using the image from this repository and that its
+protection setting has not been changed in a way that removes normal app
+device mapping. The app requires the USB mapping supplied by `usb: true`; it
+does not require full privileged mode. Replug the device and restart the app.
+
+### The kernel DVB driver claimed the RTL2832 device
+
+On a diagnostic HAOS host shell, check `lsmod` and kernel logs for
+`dvb_usb_rtl28xxu`, `rtl2832`, or related modules. Temporarily unload the
+modules only when the host permits it, for example with `modprobe -r` after
+stopping any service using the tuner. If the module must be blocked across
+reboots, use the HAOS-supported `CONFIG/modprobe` configuration mechanism and
+follow the current HAOS documentation; do not edit the container.
+
+### No AIS packets received
+
+First confirm device initialization, then verify the antenna is connected and
+vertical, the coax and connectors are sound, and there are vessels within
+radio line of sight. Try `gain: auto`, then modest fixed gain values. Verify
+that PPM is reasonable and that `channel: AB` is selected. Use AIS-catcher's
+web statistics and signal/drift plots; an empty map without nearby AIS traffic
+is not conclusive.
+
+### Bad gain
+
+Overload may appear as a high noise floor and fewer valid messages. Weak gain
+can produce sporadic or distant-only reception. Start with `auto` and change
+one setting at a time while watching valid message counts and signal levels.
+
+### Bad antenna or reception
+
+Raise and clear the antenna, keep coax short, remove unnecessary splitters,
+and compare reception at different times. AIS coverage is strongly dependent
+on local terrain, buildings, antenna height, and nearby vessel traffic.
+
+### Web UI unavailable
+
+Ensure `web.enabled: true`, restart the app, and check that AIS-catcher logged
+the web viewer startup on port 8100. Use the add-on page's **Open Web UI** or
+sidebar ingress link; do not expect a host port because none is published.
+For local Docker testing, publish `8100:8100` as shown above.
+
+## Hardware validation checklist
+
+The following items are intentionally unchecked. They require the physical
+NESDR Smart v5 and must not be marked complete based on image builds or config
+tests:
+
+- [ ] Verify USB enumeration on the Home Assistant OS host.
+- [ ] Verify AIS-catcher detects the RTL-SDR.
+- [ ] Verify AIS-catcher initializes and opens the device.
+- [ ] Determine an appropriate tuner gain.
+- [ ] Verify reception on AIS1, 161.975 MHz.
+- [ ] Verify reception on AIS2, 162.025 MHz.
+- [ ] Confirm vessels appear in AIS-catcher.
+- [ ] Confirm raw NMEA output through a configured UDP or TCP destination.
+- [ ] Confirm AISHub receives the station feed, if enabled.
+- [ ] Confirm ingress remains functional during active reception.
+- [ ] Observe CPU and memory usage on Home Assistant OS during reception.

--- a/ais-catcher/Dockerfile
+++ b/ais-catcher/Dockerfile
@@ -1,0 +1,96 @@
+# syntax=docker/dockerfile:1
+
+ARG AIS_CATCHER_COMMIT=8833c64b3da0c42e9a724b9bd13eaab2fffadcca
+ARG AIS_CATCHER_SOURCE_SHA256=597ec260638d55e51d4aea5aeccd8b4a8d9f514a1bdf637870363def645eba3c
+
+FROM docker.io/library/debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171 AS build
+
+ARG AIS_CATCHER_COMMIT
+ARG AIS_CATCHER_SOURCE_SHA256
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+  && apt-get install --no-install-recommends --yes \
+    ca-certificates \
+    cmake \
+    curl \
+    g++ \
+    libssl-dev \
+    libusb-1.0-0-dev \
+    librtlsdr-dev \
+    make \
+    patch \
+    pkg-config \
+    zlib1g-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/ais-catcher
+
+RUN curl --fail --silent --show-error --location \
+    "https://github.com/jvde-github/AIS-catcher/archive/${AIS_CATCHER_COMMIT}.tar.gz" \
+    --output /tmp/ais-catcher.tar.gz \
+  && printf '%s  %s\n' "${AIS_CATCHER_SOURCE_SHA256}" /tmp/ais-catcher.tar.gz \
+    > /tmp/ais-catcher.sha256 \
+  && sha256sum --check --strict /tmp/ais-catcher.sha256 \
+  && tar --extract --gzip --file /tmp/ais-catcher.tar.gz --strip-components=1 \
+  && rm /tmp/ais-catcher.sha256 /tmp/ais-catcher.tar.gz
+
+COPY patches/redact-uuid-from-network-logs.patch /tmp/redact-uuid-from-network-logs.patch
+
+RUN patch --strip=1 < /tmp/redact-uuid-from-network-logs.patch \
+  && rm /tmp/redact-uuid-from-network-logs.patch
+
+RUN cmake -S . -B build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/opt/ais-catcher \
+    -DRTLSDR=ON \
+    -DWEBVIEWER=ON \
+    -DOPENSSL=ON \
+    -DZLIB=ON \
+    -DAIRSPY=OFF \
+    -DAIRSPYHF=OFF \
+    -DHACKRF=OFF \
+    -DHYDRASDR=OFF \
+    -DNMEA2000=OFF \
+    -DPSQL=OFF \
+    -DSAMPLERATE=OFF \
+    -DSDRPLAY=OFF \
+    -DSOAPYSDR=OFF \
+    -DSOXR=OFF \
+    -DSQLITE=OFF \
+    -DZMQ=OFF \
+  && cmake --build build --parallel \
+  && cmake --install build
+
+FROM ghcr.io/home-assistant/base-debian:bookworm@sha256:60cd882d5200157082e568a0b775cca0d9cb5704452ada3cf6f206c4dd6d83c5
+
+ARG BUILD_VERSION=0.1.0
+ARG BUILD_ARCH
+
+LABEL \
+  io.hass.version="${BUILD_VERSION}" \
+  io.hass.type="app" \
+  io.hass.arch="${BUILD_ARCH}" \
+  org.opencontainers.image.title="AIS-catcher Home Assistant app" \
+  org.opencontainers.image.source="https://github.com/pschmitt/home-assistant-apps/tree/main/ais-catcher"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+  && apt-get install --no-install-recommends --yes \
+    ca-certificates \
+    libssl3 \
+    libusb-1.0-0 \
+    librtlsdr0 \
+    python3 \
+    zlib1g \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /opt/ais-catcher/bin/AIS-catcher /usr/bin/AIS-catcher
+COPY generate_config.py /usr/bin/generate_config.py
+COPY run.sh /run.sh
+
+RUN chmod 0755 /usr/bin/AIS-catcher /usr/bin/generate_config.py /run.sh
+
+CMD ["/run.sh"]

--- a/ais-catcher/README.md
+++ b/ais-catcher/README.md
@@ -1,0 +1,31 @@
+# AIS-catcher
+
+Receive Automatic Identification System (AIS) traffic with a USB RTL-SDR and
+[AIS-catcher](https://github.com/jvde-github/AIS-catcher). The app targets
+Home Assistant OS and provides the AIS-catcher web viewer through Home
+Assistant ingress.
+
+This app is currently experimental. It was developed without the planned
+Nooelec NESDR Smart v5 being available, so successful USB reception and radio
+performance have not been claimed or tested.
+
+See [DOCS.md](DOCS.md) for installation, configuration, troubleshooting, and
+the hardware validation checklist.
+
+The image builds AIS-catcher v0.70 from its upstream source commit. Only the
+RTL-SDR driver and built-in web viewer are enabled in the image. UDP and TCP
+outputs, AISHub, and the optional aiscatcher.org community feed all use
+AIS-catcher's native output mechanisms.
+
+## Quick start
+
+1. Add this repository to Home Assistant's add-on repository list:
+   `https://github.com/pschmitt/home-assistant-apps`.
+2. Install **AIS-catcher** from the add-on store.
+3. Connect the NESDR Smart v5, attach a suitable VHF antenna, and start the
+   app with the default configuration.
+4. Open **AIS-catcher** from the Home Assistant sidebar.
+
+For development before the SDR arrives, set `hardware_required` to `false`.
+This starts the real AIS-catcher web server with an idle UDP NMEA input. It
+does not emulate an RTL-SDR and it does not generate AIS messages.

--- a/ais-catcher/build.yaml
+++ b/ais-catcher/build.yaml
@@ -1,0 +1,3 @@
+# Home Assistant Supervisor no longer consumes build.yaml for modern apps.
+# The Dockerfile contains the explicit, pinned base image and build arguments.
+{}

--- a/ais-catcher/config.yaml
+++ b/ais-catcher/config.yaml
@@ -1,0 +1,68 @@
+name: AIS-catcher
+version: 0.1.0
+slug: ais-catcher
+description: Receive and share AIS traffic with an RTL-SDR and AIS-catcher
+url: https://github.com/pschmitt/home-assistant-apps/tree/main/ais-catcher
+arch:
+  - amd64
+  - aarch64
+startup: application
+boot: auto
+stage: experimental
+usb: true
+ingress: true
+ingress_port: 8100
+ingress_stream: true
+panel_icon: mdi:ship-wheel
+panel_title: AIS-catcher
+timeout: 30
+
+options:
+  hardware_required: true
+  receiver:
+    device: auto
+    gain: auto
+    ppm: 0
+    rtlagc: false
+    sample_rate: 1536000
+    bandwidth: 192000
+    channel: AB
+  web:
+    enabled: true
+  udp_outputs: []
+  tcp_outputs: []
+  aishub:
+    enabled: false
+    host: ""
+    port: 0
+  aiscatcher_share:
+    enabled: false
+    key: ""
+  log_level: info
+
+schema:
+  hardware_required: bool
+  receiver:
+    device: str
+    gain: str
+    ppm: int(-150,150)
+    rtlagc: bool
+    sample_rate: int(12500,12288000)
+    bandwidth: int(0,1000000)
+    channel: list(AB|CD)
+  web:
+    enabled: bool
+  udp_outputs:
+    - host: str
+      port: int(1,65535)
+  tcp_outputs:
+    - host: str
+      port: int(1,65535)
+  aishub:
+    enabled: bool
+    host: str
+    port: int(0,65535)
+  aiscatcher_share:
+    enabled: bool
+    key: password
+  log_level: list(debug|info|warning|error|critical)

--- a/ais-catcher/generate_config.py
+++ b/ais-catcher/generate_config.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Translate Home Assistant app options into an AIS-catcher JSON config."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import pathlib
+import re
+import sys
+import tempfile
+from typing import Any
+
+
+DEFAULTS: dict[str, Any] = {
+    "hardware_required": True,
+    "receiver": {
+        "device": "auto",
+        "gain": "auto",
+        "ppm": 0,
+        "rtlagc": False,
+        "sample_rate": 1536000,
+        "bandwidth": 192000,
+        "channel": "AB",
+    },
+    "web": {"enabled": True},
+    "udp_outputs": [],
+    "tcp_outputs": [],
+    "aishub": {"enabled": False, "host": "", "port": 0},
+    "aiscatcher_share": {"enabled": False, "key": ""},
+    "log_level": "info",
+}
+
+TOP_LEVEL_KEYS = set(DEFAULTS)
+RECEIVER_KEYS = set(DEFAULTS["receiver"])
+WEB_KEYS = set(DEFAULTS["web"])
+AISHUB_KEYS = set(DEFAULTS["aishub"])
+SHARE_KEYS = set(DEFAULTS["aiscatcher_share"])
+LOG_LEVELS = {"debug", "info", "warning", "error", "critical"}
+UUID_PATTERN = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
+
+class ConfigurationError(ValueError):
+    """An invalid Home Assistant option."""
+
+
+def fail(message: str) -> ConfigurationError:
+    return ConfigurationError(f"invalid configuration: {message}")
+
+
+def require_type(value: Any, expected: type, name: str) -> Any:
+    if not isinstance(value, expected) or (expected is int and isinstance(value, bool)):
+        raise fail(f"{name} must be {expected.__name__}")
+    return value
+
+
+def require_keys(value: dict[str, Any], allowed: set[str], name: str) -> None:
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise fail(f"unknown option(s) in {name}: {', '.join(unknown)}")
+
+
+def merged_options(options: Any) -> dict[str, Any]:
+    require_type(options, dict, "top-level options")
+    require_keys(options, TOP_LEVEL_KEYS, "top-level options")
+    result = copy.deepcopy(DEFAULTS)
+    for key, value in options.items():
+        if isinstance(result.get(key), dict) and isinstance(value, dict):
+            result[key].update(value)
+        else:
+            result[key] = value
+    return result
+
+
+def validate_options(options: dict[str, Any]) -> None:
+    require_type(options["hardware_required"], bool, "hardware_required")
+
+    receiver = require_type(options["receiver"], dict, "receiver")
+    require_keys(receiver, RECEIVER_KEYS, "receiver")
+    device = require_type(receiver["device"], str, "receiver.device")
+    if not device.strip():
+        raise fail("receiver.device must not be empty")
+    gain = require_type(receiver["gain"], str, "receiver.gain")
+    if gain.lower() != "auto":
+        try:
+            gain_value = float(gain)
+        except ValueError as error:
+            raise fail("receiver.gain must be auto or a number from 0 to 50") from error
+        if not 0 <= gain_value <= 50:
+            raise fail("receiver.gain must be auto or a number from 0 to 50")
+    ppm = require_type(receiver["ppm"], int, "receiver.ppm")
+    if not -150 <= ppm <= 150:
+        raise fail("receiver.ppm must be between -150 and 150")
+    require_type(receiver["rtlagc"], bool, "receiver.rtlagc")
+    sample_rate = require_type(receiver["sample_rate"], int, "receiver.sample_rate")
+    if not 12500 <= sample_rate <= 12288000:
+        raise fail("receiver.sample_rate must be between 12500 and 12288000")
+    bandwidth = require_type(receiver["bandwidth"], int, "receiver.bandwidth")
+    if not 0 <= bandwidth <= 1000000:
+        raise fail("receiver.bandwidth must be between 0 and 1000000")
+    if receiver["channel"] not in {"AB", "CD"}:
+        raise fail("receiver.channel must be AB or CD")
+
+    web = require_type(options["web"], dict, "web")
+    require_keys(web, WEB_KEYS, "web")
+    require_type(web["enabled"], bool, "web.enabled")
+
+    validate_outputs(options["udp_outputs"], "udp_outputs")
+    validate_outputs(options["tcp_outputs"], "tcp_outputs")
+
+    aishub = require_type(options["aishub"], dict, "aishub")
+    require_keys(aishub, AISHUB_KEYS, "aishub")
+    require_type(aishub["enabled"], bool, "aishub.enabled")
+    require_type(aishub["host"], str, "aishub.host")
+    port = require_type(aishub["port"], int, "aishub.port")
+    if not 0 <= port <= 65535:
+        raise fail("aishub.port must be between 0 and 65535")
+    if aishub["enabled"] and (not aishub["host"].strip() or port == 0):
+        raise fail("aishub.host and aishub.port are required when AISHub is enabled")
+
+    sharing = require_type(options["aiscatcher_share"], dict, "aiscatcher_share")
+    require_keys(sharing, SHARE_KEYS, "aiscatcher_share")
+    require_type(sharing["enabled"], bool, "aiscatcher_share.enabled")
+    require_type(sharing["key"], str, "aiscatcher_share.key")
+    if sharing["enabled"] and not sharing["key"].strip():
+        raise fail("aiscatcher_share.key is required when sharing is enabled")
+    if sharing["key"] and not UUID_PATTERN.fullmatch(sharing["key"]):
+        raise fail("aiscatcher_share.key must be a UUID supplied by aiscatcher.org")
+    log_level = require_type(options["log_level"], str, "log_level")
+    if log_level not in LOG_LEVELS:
+        raise fail(f"log_level must be one of: {', '.join(sorted(LOG_LEVELS))}")
+
+
+def validate_outputs(outputs: Any, name: str) -> None:
+    require_type(outputs, list, name)
+    for index, output in enumerate(outputs):
+        output_name = f"{name}[{index}]"
+        output = require_type(output, dict, output_name)
+        require_keys(output, {"host", "port"}, output_name)
+        host = require_type(output.get("host"), str, f"{output_name}.host")
+        if not host.strip():
+            raise fail(f"{output_name}.host must not be empty")
+        port = require_type(output.get("port"), int, f"{output_name}.port")
+        if not 1 <= port <= 65535:
+            raise fail(f"{output_name}.port must be between 1 and 65535")
+
+
+def build_config(options: dict[str, Any]) -> dict[str, Any]:
+    receiver_options = options["receiver"]
+    if options["hardware_required"]:
+        receiver: dict[str, Any] = {
+            "input": "rtlsdr",
+            "channel": receiver_options["channel"],
+            "rtlsdr": {
+                "tuner": (
+                    receiver_options["gain"].lower()
+                    if receiver_options["gain"].lower() == "auto"
+                    else receiver_options["gain"]
+                ),
+                "rtlagc": receiver_options["rtlagc"],
+                "freqoffset": receiver_options["ppm"],
+                "sample_rate": receiver_options["sample_rate"],
+                "bandwidth": receiver_options["bandwidth"],
+            },
+        }
+        if receiver_options["device"].lower() != "auto":
+            receiver["serial"] = receiver_options["device"]
+        mode = "hardware"
+    else:
+        # This is a real AIS-catcher UDP NMEA input, not an SDR simulator. It
+        # keeps the native web viewer available while waiting for hardware.
+        receiver = {
+            "input": "udpserver",
+            "udpserver": {"server": "127.0.0.1", "port": 10110},
+        }
+        mode = "no-hardware"
+
+    config: dict[str, Any] = {
+        "config": "aiscatcher",
+        "version": 1,
+        "screen": 0,
+        "receiver": [receiver],
+        "udp": [
+            {"active": True, "host": output["host"], "port": output["port"]}
+            for output in options["udp_outputs"]
+        ],
+        "tcp": [
+            {"active": True, "host": output["host"], "port": output["port"]}
+            for output in options["tcp_outputs"]
+        ],
+    }
+    if options["aishub"]["enabled"]:
+        config["udp"].append(
+            {
+                "active": True,
+                "host": options["aishub"]["host"],
+                "port": options["aishub"]["port"],
+            }
+        )
+    if options["web"]["enabled"]:
+        config["server"] = [{"active": True, "port": 8100}]
+    else:
+        config["server"] = []
+    config["sharing"] = options["aiscatcher_share"]["enabled"]
+    if options["aiscatcher_share"]["enabled"]:
+        config["sharing_key"] = options["aiscatcher_share"]["key"]
+    return {"mode": mode, "log_level": options["log_level"], "config": config}
+
+
+def redact(config: dict[str, Any]) -> dict[str, Any]:
+    result = copy.deepcopy(config)
+    if "sharing_key" in result:
+        result["sharing_key"] = "<redacted>"
+    return result
+
+
+def load_options(path: pathlib.Path) -> dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as options_file:
+            return merged_options(json.load(options_file))
+    except FileNotFoundError as error:
+        raise fail(f"options file does not exist: {path}") from error
+    except json.JSONDecodeError as error:
+        raise fail(f"options file is not valid JSON: {error}") from error
+
+
+def write_config(path: pathlib.Path, config: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", dir=path.parent, text=True
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as config_file:
+            json.dump(config, config_file, indent=2)
+            config_file.write("\n")
+        os.chmod(temporary_name, 0o600)
+        os.replace(temporary_name, path)
+    except BaseException:
+        os.unlink(temporary_name)
+        raise
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--options", type=pathlib.Path, default=pathlib.Path("/data/options.json"))
+    parser.add_argument("--output", type=pathlib.Path, default=pathlib.Path("/data/aiscatcher.json"))
+    parser.add_argument("--print-redacted", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        options = load_options(args.options)
+        validate_options(options)
+        result = build_config(options)
+        write_config(args.output, result["config"])
+    except (ConfigurationError, OSError) as error:
+        print(error, file=sys.stderr)
+        return 2
+
+    if args.print_redacted:
+        print(json.dumps(redact(result["config"]), indent=2))
+    else:
+        print(f"{result['mode']}|{result['log_level']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ais-catcher/generate_config.py
+++ b/ais-catcher/generate_config.py
@@ -100,7 +100,8 @@ def validate_options(options: dict[str, Any]) -> None:
     bandwidth = require_type(receiver["bandwidth"], int, "receiver.bandwidth")
     if not 0 <= bandwidth <= 1000000:
         raise fail("receiver.bandwidth must be between 0 and 1000000")
-    if receiver["channel"] not in {"AB", "CD"}:
+    channel = require_type(receiver["channel"], str, "receiver.channel")
+    if channel not in {"AB", "CD"}:
         raise fail("receiver.channel must be AB or CD")
 
     web = require_type(options["web"], dict, "web")

--- a/ais-catcher/patches/redact-uuid-from-network-logs.patch
+++ b/ais-catcher/patches/redact-uuid-from-network-logs.patch
@@ -1,0 +1,9 @@
+diff --git a/Source/IO/Network.cpp b/Source/IO/Network.cpp
+--- a/Source/IO/Network.cpp
++++ b/Source/IO/Network.cpp
+@@ -428,1 +428,1 @@
+-			ss << ", uuid: " << uuid;
++			ss << ", uuid: [redacted]";
+@@ -590,1 +590,1 @@
+-			ss << ", uuid: " << uuid;
++			ss << ", uuid: [redacted]";

--- a/ais-catcher/run.sh
+++ b/ais-catcher/run.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly OPTIONS_PATH=/data/options.json
+readonly CONFIG_PATH=/data/aiscatcher.json
+
+main() {
+  local summary mode log_level
+  local -a ais_args
+
+  if [[ ! -r "${OPTIONS_PATH}" ]]
+  then
+    printf 'AIS-catcher: %s is missing or unreadable.\n' "${OPTIONS_PATH}" >&2
+    return 2
+  fi
+
+  summary="$(python3 /usr/bin/generate_config.py \
+    --options "${OPTIONS_PATH}" \
+    --output "${CONFIG_PATH}")"
+  IFS='|' read -r mode log_level <<< "${summary}"
+
+  printf 'AIS-catcher: generated configuration (%s mode, log level %s).\n' \
+    "${mode}" "${log_level}"
+
+  if [[ "${mode}" == "hardware" ]]
+  then
+    printf 'AIS-catcher: RTL-SDR access is required; no SDR data is simulated.\n'
+    printf 'AIS-catcher: enumerating devices before starting the receiver:\n'
+    if ! /usr/bin/AIS-catcher -l JSON on
+    then
+      printf 'AIS-catcher: device enumeration command failed; receiver startup will show the cause.\n' >&2
+    fi
+  else
+    printf 'AIS-catcher: no-hardware mode uses an idle UDP NMEA input on 127.0.0.1:10110.\n'
+    printf 'AIS-catcher: no radio reception or fabricated AIS data will be produced.\n'
+  fi
+
+  ais_args=(
+    -G LEVEL "${log_level^^}"
+    -C "${CONFIG_PATH}"
+  )
+  exec /usr/bin/AIS-catcher "${ais_args[@]}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]
+then
+  main "$@"
+fi
+
+# vim: set ft=sh et ts=2 sw=2 :

--- a/ais-catcher/tests/check.sh
+++ b/ais-catcher/tests/check.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+APP_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+readonly APP_DIR
+
+main() {
+  python3 "${SCRIPT_DIR}/test_config.py"
+  python3 -m json.tool "${SCRIPT_DIR}/options/minimal.json" >/dev/null
+  python3 -m json.tool "${SCRIPT_DIR}/options/full.json" >/dev/null
+  python3 -m json.tool "${SCRIPT_DIR}/options/no-hardware.json" >/dev/null
+  python3 -m json.tool "${SCRIPT_DIR}/options/no-hardware-sharing.json" >/dev/null
+  yq '.' "${APP_DIR}/config.yaml" >/dev/null
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]
+then
+  main "$@"
+fi
+
+# vim: set ft=sh et ts=2 sw=2 :

--- a/ais-catcher/tests/options/full.json
+++ b/ais-catcher/tests/options/full.json
@@ -1,0 +1,37 @@
+{
+  "hardware_required": true,
+  "receiver": {
+    "device": "NESDR-TEST-SERIAL",
+    "gain": "32.8",
+    "ppm": -3,
+    "rtlagc": true,
+    "sample_rate": 1536000,
+    "bandwidth": 192000,
+    "channel": "AB"
+  },
+  "web": {
+    "enabled": true
+  },
+  "udp_outputs": [
+    {
+      "host": "192.0.2.10",
+      "port": 10110
+    }
+  ],
+  "tcp_outputs": [
+    {
+      "host": "ais-consumer.example",
+      "port": 4001
+    }
+  ],
+  "aishub": {
+    "enabled": true,
+    "host": "aishub.example",
+    "port": 12345
+  },
+  "aiscatcher_share": {
+    "enabled": true,
+    "key": "123e4567-e89b-12d3-a456-426614174000"
+  },
+  "log_level": "debug"
+}

--- a/ais-catcher/tests/options/minimal.json
+++ b/ais-catcher/tests/options/minimal.json
@@ -1,0 +1,27 @@
+{
+  "hardware_required": true,
+  "receiver": {
+    "device": "auto",
+    "gain": "auto",
+    "ppm": 0,
+    "rtlagc": false,
+    "sample_rate": 1536000,
+    "bandwidth": 192000,
+    "channel": "AB"
+  },
+  "web": {
+    "enabled": true
+  },
+  "udp_outputs": [],
+  "tcp_outputs": [],
+  "aishub": {
+    "enabled": false,
+    "host": "",
+    "port": 0
+  },
+  "aiscatcher_share": {
+    "enabled": false,
+    "key": ""
+  },
+  "log_level": "info"
+}

--- a/ais-catcher/tests/options/no-hardware-sharing.json
+++ b/ais-catcher/tests/options/no-hardware-sharing.json
@@ -1,0 +1,27 @@
+{
+  "hardware_required": false,
+  "receiver": {
+    "device": "auto",
+    "gain": "auto",
+    "ppm": 0,
+    "rtlagc": false,
+    "sample_rate": 1536000,
+    "bandwidth": 192000,
+    "channel": "AB"
+  },
+  "web": {
+    "enabled": true
+  },
+  "udp_outputs": [],
+  "tcp_outputs": [],
+  "aishub": {
+    "enabled": false,
+    "host": "",
+    "port": 0
+  },
+  "aiscatcher_share": {
+    "enabled": true,
+    "key": "123e4567-e89b-12d3-a456-426614174000"
+  },
+  "log_level": "info"
+}

--- a/ais-catcher/tests/options/no-hardware.json
+++ b/ais-catcher/tests/options/no-hardware.json
@@ -1,0 +1,27 @@
+{
+  "hardware_required": false,
+  "receiver": {
+    "device": "auto",
+    "gain": "auto",
+    "ppm": 0,
+    "rtlagc": false,
+    "sample_rate": 1536000,
+    "bandwidth": 192000,
+    "channel": "AB"
+  },
+  "web": {
+    "enabled": true
+  },
+  "udp_outputs": [],
+  "tcp_outputs": [],
+  "aishub": {
+    "enabled": false,
+    "host": "",
+    "port": 0
+  },
+  "aiscatcher_share": {
+    "enabled": false,
+    "key": ""
+  },
+  "log_level": "info"
+}

--- a/ais-catcher/tests/test_config.py
+++ b/ais-catcher/tests/test_config.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Tests for the options-to-AIS-catcher configuration boundary."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import stat
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+GENERATOR = ROOT / "generate_config.py"
+OPTIONS = ROOT / "tests" / "options"
+
+
+class ConfigGenerationTests(unittest.TestCase):
+    def run_generator(self, fixture: str, *extra: str) -> tuple[subprocess.CompletedProcess[str], pathlib.Path]:
+        temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary_directory.cleanup)
+        output = pathlib.Path(temporary_directory.name) / "aiscatcher.json"
+        process = subprocess.run(
+            [
+                "python3",
+                str(GENERATOR),
+                "--options",
+                str(OPTIONS / fixture),
+                "--output",
+                str(output),
+                *extra,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return process, output
+
+    def test_minimal_configuration_uses_auto_rtl_sdr_and_ingress_server(self) -> None:
+        process, output = self.run_generator("minimal.json")
+        self.assertEqual(process.returncode, 0, process.stderr)
+        self.assertEqual(process.stdout.strip(), "hardware|info")
+        config = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(config["receiver"][0]["input"], "rtlsdr")
+        self.assertNotIn("serial", config["receiver"][0])
+        self.assertEqual(config["receiver"][0]["rtlsdr"]["tuner"], "auto")
+        self.assertEqual(config["receiver"][0]["rtlsdr"]["freqoffset"], 0)
+        self.assertEqual(config["server"], [{"active": True, "port": 8100}])
+        self.assertEqual(config["udp"], [])
+        self.assertEqual(config["tcp"], [])
+
+    def test_full_configuration_maps_outputs_and_sharing(self) -> None:
+        process, output = self.run_generator("full.json")
+        self.assertEqual(process.returncode, 0, process.stderr)
+        self.assertEqual(process.stdout.strip(), "hardware|debug")
+        config = json.loads(output.read_text(encoding="utf-8"))
+        receiver = config["receiver"][0]
+        self.assertEqual(receiver["serial"], "NESDR-TEST-SERIAL")
+        self.assertEqual(receiver["rtlsdr"]["tuner"], "32.8")
+        self.assertEqual(receiver["rtlsdr"]["freqoffset"], -3)
+        self.assertEqual(config["udp"], [
+            {"active": True, "host": "192.0.2.10", "port": 10110},
+            {"active": True, "host": "aishub.example", "port": 12345},
+        ])
+        self.assertEqual(config["tcp"], [{
+            "active": True,
+            "host": "ais-consumer.example",
+            "port": 4001,
+        }])
+        self.assertTrue(config["sharing"])
+        self.assertEqual(config["sharing_key"], "123e4567-e89b-12d3-a456-426614174000")
+
+    def test_redacted_output_does_not_contain_sharing_key(self) -> None:
+        process, output = self.run_generator("full.json", "--print-redacted")
+        self.assertEqual(process.returncode, 0, process.stderr)
+        self.assertNotIn("123e4567-e89b-12d3-a456-426614174000", process.stdout)
+        self.assertIn('"sharing_key": "<redacted>"', process.stdout)
+        self.assertIn("123e4567-e89b-12d3-a456-426614174000", output.read_text(encoding="utf-8"))
+        self.assertEqual(stat.S_IMODE(output.stat().st_mode), 0o600)
+
+    def test_no_hardware_mode_is_native_idle_udp_input(self) -> None:
+        process, output = self.run_generator("no-hardware.json")
+        self.assertEqual(process.returncode, 0, process.stderr)
+        self.assertEqual(process.stdout.strip(), "no-hardware|info")
+        config = json.loads(output.read_text(encoding="utf-8"))
+        receiver = config["receiver"][0]
+        self.assertEqual(receiver["input"], "udpserver")
+        self.assertEqual(receiver["udpserver"], {"server": "127.0.0.1", "port": 10110})
+        self.assertNotIn("rtlsdr", json.dumps(config))
+
+    def test_invalid_options_fail_before_writing_configuration(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            options = pathlib.Path(temporary_directory) / "options.json"
+            output = pathlib.Path(temporary_directory) / "config.json"
+            base = json.loads((OPTIONS / "minimal.json").read_text(encoding="utf-8"))
+            base["receiver"]["ppm"] = 151
+            options.write_text(json.dumps(base), encoding="utf-8")
+            process = subprocess.run(
+                [
+                    "python3",
+                    str(GENERATOR),
+                    "--options",
+                    str(options),
+                    "--output",
+                    str(output),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(process.returncode, 2)
+        self.assertIn("receiver.ppm", process.stderr)
+        self.assertFalse(output.exists())
+
+    def test_enabled_aishub_requires_endpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            options = pathlib.Path(temporary_directory) / "options.json"
+            output = pathlib.Path(temporary_directory) / "config.json"
+            base = json.loads((OPTIONS / "minimal.json").read_text(encoding="utf-8"))
+            base["aishub"]["enabled"] = True
+            options.write_text(json.dumps(base), encoding="utf-8")
+            process = subprocess.run(
+                [
+                    "python3",
+                    str(GENERATOR),
+                    "--options",
+                    str(options),
+                    "--output",
+                    str(output),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(process.returncode, 2)
+        self.assertIn("AISHub", process.stderr)
+
+    def test_invalid_community_key_fails_before_writing_configuration(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            options = pathlib.Path(temporary_directory) / "options.json"
+            output = pathlib.Path(temporary_directory) / "config.json"
+            base = json.loads((OPTIONS / "full.json").read_text(encoding="utf-8"))
+            base["aiscatcher_share"]["key"] = "not-a-community-uuid"
+            options.write_text(json.dumps(base), encoding="utf-8")
+            process = subprocess.run(
+                [
+                    "python3",
+                    str(GENERATOR),
+                    "--options",
+                    str(options),
+                    "--output",
+                    str(output),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(process.returncode, 2)
+        self.assertIn("must be a UUID", process.stderr)
+        self.assertFalse(output.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ais-catcher/tests/test_config.py
+++ b/ais-catcher/tests/test_config.py
@@ -109,9 +109,10 @@ class ConfigGenerationTests(unittest.TestCase):
                 text=True,
                 check=False,
             )
+            output_exists = output.exists()
         self.assertEqual(process.returncode, 2)
         self.assertIn("receiver.ppm", process.stderr)
-        self.assertFalse(output.exists())
+        self.assertFalse(output_exists)
 
     def test_enabled_aishub_requires_endpoint(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -133,8 +134,10 @@ class ConfigGenerationTests(unittest.TestCase):
                 text=True,
                 check=False,
             )
+            output_exists = output.exists()
         self.assertEqual(process.returncode, 2)
         self.assertIn("AISHub", process.stderr)
+        self.assertFalse(output_exists)
 
     def test_invalid_community_key_fails_before_writing_configuration(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -156,9 +159,35 @@ class ConfigGenerationTests(unittest.TestCase):
                 text=True,
                 check=False,
             )
+            output_exists = output.exists()
         self.assertEqual(process.returncode, 2)
         self.assertIn("must be a UUID", process.stderr)
-        self.assertFalse(output.exists())
+        self.assertFalse(output_exists)
+
+    def test_non_string_channel_fails_as_configuration_error(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            options = pathlib.Path(temporary_directory) / "options.json"
+            output = pathlib.Path(temporary_directory) / "config.json"
+            base = json.loads((OPTIONS / "minimal.json").read_text(encoding="utf-8"))
+            base["receiver"]["channel"] = []
+            options.write_text(json.dumps(base), encoding="utf-8")
+            process = subprocess.run(
+                [
+                    "python3",
+                    str(GENERATOR),
+                    "--options",
+                    str(options),
+                    "--output",
+                    str(output),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            output_exists = output.exists()
+        self.assertEqual(process.returncode, 2)
+        self.assertIn("receiver.channel", process.stderr)
+        self.assertFalse(output_exists)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add an experimental AIS-catcher Home Assistant OS app for RTL-SDR AIS reception.
- Build AIS-catcher v0.70 reproducibly for amd64 and aarch64.
- Add USB access, Home Assistant ingress, configurable receiver settings, UDP/TCP NMEA outputs, AISHub, and optional community sharing.
- Add explicit no-hardware development mode without fabricated AIS data.
- Add configuration tests, fixtures, ShellCheck/Hadolint checks, Docker validation, and documentation.
- Redact community UUIDs from upstream network startup logs.

## Validation

- Configuration tests: 7 passed.
- ShellCheck passed.
- Hadolint passed.
- YAML/JSON validation passed.
- amd64 image built successfully.
- No-hardware container and web UI/ingress port validated.
- Sharing enabled without exposing the configured UUID in logs.

## Hardware follow-up

The physical NESDR Smart v5 is not yet available. USB enumeration, RTL-SDR initialization, gain/PPM tuning, AIS1/AIS2 reception, raw NMEA output, AISHub delivery, and HAOS resource usage remain unverified and are documented in the hardware validation checklist.
